### PR TITLE
feat: Implement ImageSet move to folder feature (#10)

### DIFF
--- a/docs/issue10_move_to_folder.md
+++ b/docs/issue10_move_to_folder.md
@@ -1,0 +1,54 @@
+# Feature: Move ImageSet(s) to Target Folder
+
+This feature allows users to move one or more `ImageSets` to a selected target folder via the web interface.
+
+---
+
+## Implementation Steps
+
+1. **Add Method to `ImageSet` Class**
+
+   * Implement a method that enables moving an `ImageSet` instance to a different folder.
+   * Ensure all associated metadata and references are updated accordingly.
+   * input is new folder
+   * output is the full os path to the new folder
+
+2. **Add API Route and View**
+
+   * Create an API endpoint that handles the folder move action.
+   * The route should accept an `ImageSet` ID and the target folder ID as parameters.
+   * Return success/failure responses in JSON format.
+
+3. **Create HTML Route, View, and Template**
+
+   * Develop a dialog form that allows the user to select a new folder for the chosen `ImageSet`.
+   * The dialog should provide a clear list or dropdown of available folders.
+   * Include client-side validation and user feedback messages.
+
+---
+
+## UI Integration
+
+4. **ImageSet Page Enhancements**
+
+   * Add a button labeled **“Move ImageSet”** on each ImageSet’s detail page.
+   * Clicking this button should open the “Move ImageSet” dialog form.
+
+5. **Folder Page Enhancements (Per ImageSet)**
+
+   * On the folder page, add a **“Move”** button to each ImageSet card.
+   * This button should allow the user to move that specific ImageSet to another folder.
+
+6. **Folder Page Enhancements (Bulk Actions)**
+
+   * Add a **“Move All”** button that moves all ImageSets in the current folder to a target folder.
+   * After completion, redirect or refresh the view to display the target folder’s contents.
+
+7. **Folder Page Enhancements (By Status)**
+
+   * On each **status count card**, add a **“Move”** button that moves all ImageSets with that status to a selected folder.
+   * The user should be prompted to confirm or select the destination folder before the operation proceeds.
+
+
+
+

--- a/img_catalog_tui/flask/templates/folder.html
+++ b/img_catalog_tui/flask/templates/folder.html
@@ -30,7 +30,10 @@
             <div class="card">
                 <div class="card-content text-center">
                     <div style="font-size: 2rem; font-weight: bold; color: var(--accent);">{{ count }}</div>
-                    <div style="font-size: 0.875rem; color: var(--text); opacity: 0.8;">{{ status or 'new' }}</div>
+                    <div style="font-size: 0.875rem; color: var(--text); opacity: 0.8; margin-bottom: var(--space-sm);">{{ status or 'new' }}</div>
+                    <button onclick="openMoveByStatusDialog('{{ status or 'new' }}')" class="btn btn-secondary" style="padding: var(--space-xs) var(--space-sm); font-size: 0.8rem;">
+                        📦 Move
+                    </button>
                 </div>
             </div>
             {% endfor %}
@@ -45,6 +48,9 @@
                 <a href="/folder/{{ foldername }}/batch_update" class="btn btn-primary">
                     🔄 Batch Update Imagesets
                 </a>
+                <button onclick="openMoveAllDialog()" class="btn btn-primary">
+                    📦 Move All Imagesets
+                </button>
             </div>
         </div>
     </div>
@@ -120,8 +126,15 @@
                                 </div>
                             </div>
                             
-                            <div class="card-footer">
+                            <div class="card-footer" style="display: flex; justify-content: space-between; align-items: center;">
                                 <span style="font-size: 0.875rem; color: var(--text); opacity: 0.8;">Click to view details →</span>
+                                <a href="/imageset/{{ foldername }}/{{ imageset_name }}/move" 
+                                   class="btn btn-primary" 
+                                   style="padding: var(--space-xs) var(--space-sm); font-size: 0.8rem;" 
+                                   target="_blank"
+                                   onclick="event.stopPropagation();">
+                                    📦 Move
+                                </a>
                             </div>
                         </div>
                     </a>
@@ -134,4 +147,212 @@
         {% endif %}
     </div>
 {% endif %}
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+// Get available folders for dropdown
+const availableFolders = {{ folder_data | tojson if folder_data else '{}' }};
+
+// Fetch all available folders from API
+async function getAvailableFolders() {
+    try {
+        const response = await fetch('/api/folders');
+        if (!response.ok) {
+            throw new Error('Failed to fetch folders');
+        }
+        return await response.json();
+    } catch (error) {
+        console.error('Error fetching folders:', error);
+        return {};
+    }
+}
+
+// Open dialog for moving all imagesets
+async function openMoveAllDialog() {
+    const folders = await getAvailableFolders();
+    const currentFolder = '{{ foldername }}';
+    
+    // Filter out current folder
+    const targetFolders = Object.keys(folders).filter(f => f !== currentFolder);
+    
+    if (targetFolders.length === 0) {
+        alert('No other folders available to move to.');
+        return;
+    }
+    
+    // Create options for select
+    const options = targetFolders.map(f => `<option value="${f}">${f}</option>`).join('');
+    
+    // Create custom dialog
+    const dialogHTML = `
+        <div id="moveDialog" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;">
+            <div style="background: var(--bg); padding: var(--space-lg); border-radius: var(--radius-md); max-width: 500px; width: 90%;">
+                <h3 style="margin-top: 0; color: var(--accent);">📦 Move All Imagesets</h3>
+                <p style="color: var(--text);">Select the destination folder for ALL imagesets in this folder.</p>
+                <select id="targetFolderSelect" style="width: 100%; padding: var(--space-sm); border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg); color: var(--text); margin-bottom: var(--space-md);">
+                    <option value="">Select folder...</option>
+                    ${options}
+                </select>
+                <div style="display: flex; gap: var(--space-md); justify-content: flex-end;">
+                    <button onclick="closeMoveDialog()" class="btn btn-secondary">Cancel</button>
+                    <button onclick="executeMoveAll()" class="btn btn-primary">Move All</button>
+                </div>
+                <div id="moveStatus" style="margin-top: var(--space-md);"></div>
+            </div>
+        </div>
+    `;
+    
+    document.body.insertAdjacentHTML('beforeend', dialogHTML);
+}
+
+// Open dialog for moving imagesets by status
+async function openMoveByStatusDialog(status) {
+    const folders = await getAvailableFolders();
+    const currentFolder = '{{ foldername }}';
+    
+    // Filter out current folder
+    const targetFolders = Object.keys(folders).filter(f => f !== currentFolder);
+    
+    if (targetFolders.length === 0) {
+        alert('No other folders available to move to.');
+        return;
+    }
+    
+    // Create options for select
+    const options = targetFolders.map(f => `<option value="${f}">${f}</option>`).join('');
+    
+    // Create custom dialog
+    const dialogHTML = `
+        <div id="moveDialog" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;">
+            <div style="background: var(--bg); padding: var(--space-lg); border-radius: var(--radius-md); max-width: 500px; width: 90%;">
+                <h3 style="margin-top: 0; color: var(--accent);">📦 Move Imagesets by Status</h3>
+                <p style="color: var(--text);">Move all imagesets with status "<strong>${status}</strong>" to the selected folder.</p>
+                <select id="targetFolderSelect" style="width: 100%; padding: var(--space-sm); border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg); color: var(--text); margin-bottom: var(--space-md);">
+                    <option value="">Select folder...</option>
+                    ${options}
+                </select>
+                <div style="display: flex; gap: var(--space-md); justify-content: flex-end;">
+                    <button onclick="closeMoveDialog()" class="btn btn-secondary">Cancel</button>
+                    <button onclick="executeMoveByStatus('${status}')" class="btn btn-primary">Move</button>
+                </div>
+                <div id="moveStatus" style="margin-top: var(--space-md);"></div>
+            </div>
+        </div>
+    `;
+    
+    document.body.insertAdjacentHTML('beforeend', dialogHTML);
+}
+
+// Close move dialog
+function closeMoveDialog() {
+    const dialog = document.getElementById('moveDialog');
+    if (dialog) {
+        dialog.remove();
+    }
+}
+
+// Execute move all operation
+async function executeMoveAll() {
+    const targetFolder = document.getElementById('targetFolderSelect').value;
+    const statusDiv = document.getElementById('moveStatus');
+    
+    if (!targetFolder) {
+        statusDiv.innerHTML = '<div class="error-message">Please select a target folder.</div>';
+        return;
+    }
+    
+    if (!confirm(`Are you sure you want to move ALL imagesets to "${targetFolder}"?`)) {
+        return;
+    }
+    
+    statusDiv.innerHTML = '<div style="color: var(--text);">⏳ Moving imagesets...</div>';
+    
+    try {
+        const response = await fetch('/api/folder/{{ foldername }}/move_imagesets', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                target_foldername: targetFolder
+            })
+        });
+        
+        const data = await response.json();
+        
+        if (response.ok || response.status === 207) {
+            statusDiv.innerHTML = `<div style="color: var(--accent);">✅ Moved ${data.successful_count} imageset(s) successfully!</div>`;
+            if (data.failed_count > 0) {
+                statusDiv.innerHTML += `<div style="color: var(--text); opacity: 0.8; margin-top: var(--space-xs);">⚠️ ${data.failed_count} failed</div>`;
+            }
+            
+            // Refresh page after short delay
+            setTimeout(() => {
+                window.location.reload();
+            }, 2000);
+        } else {
+            statusDiv.innerHTML = `<div class="error-message">❌ Error: ${data.error || 'Failed to move imagesets'}</div>`;
+        }
+    } catch (error) {
+        statusDiv.innerHTML = `<div class="error-message">❌ Error: ${error.message}</div>`;
+    }
+}
+
+// Execute move by status operation
+async function executeMoveByStatus(status) {
+    const targetFolder = document.getElementById('targetFolderSelect').value;
+    const statusDiv = document.getElementById('moveStatus');
+    
+    if (!targetFolder) {
+        statusDiv.innerHTML = '<div class="error-message">Please select a target folder.</div>';
+        return;
+    }
+    
+    if (!confirm(`Are you sure you want to move all imagesets with status "${status}" to "${targetFolder}"?`)) {
+        return;
+    }
+    
+    statusDiv.innerHTML = '<div style="color: var(--text);">⏳ Moving imagesets...</div>';
+    
+    try {
+        const response = await fetch('/api/folder/{{ foldername }}/move_imagesets', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                target_foldername: targetFolder,
+                filter_status: status
+            })
+        });
+        
+        const data = await response.json();
+        
+        if (response.ok || response.status === 207) {
+            statusDiv.innerHTML = `<div style="color: var(--accent);">✅ Moved ${data.successful_count} imageset(s) successfully!</div>`;
+            if (data.failed_count > 0) {
+                statusDiv.innerHTML += `<div style="color: var(--text); opacity: 0.8; margin-top: var(--space-xs);">⚠️ ${data.failed_count} failed</div>`;
+            }
+            
+            // Refresh page after short delay
+            setTimeout(() => {
+                window.location.reload();
+            }, 2000);
+        } else {
+            statusDiv.innerHTML = `<div class="error-message">❌ Error: ${data.error || 'Failed to move imagesets'}</div>`;
+        }
+    } catch (error) {
+        statusDiv.innerHTML = `<div class="error-message">❌ Error: ${error.message}</div>`;
+    }
+}
+
+// Close dialog on escape key
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        closeMoveDialog();
+    }
+});
+</script>
 {% endblock %}

--- a/img_catalog_tui/flask/templates/imageset.html
+++ b/img_catalog_tui/flask/templates/imageset.html
@@ -192,6 +192,9 @@
                     <a href="/imageset/{{ foldername }}/{{ imageset_name }}/interview" class="btn btn-primary" target="_blank">
                         🚀 Interview
                     </a>
+                    <a href="/imageset/{{ foldername }}/{{ imageset_name }}/move" class="btn btn-primary" target="_blank">
+                        📦 Move ImageSet
+                    </a>
                     <button class="btn btn-secondary" onclick="copyFolderPath()">
                         📁 Copy Folder
                     </button>

--- a/img_catalog_tui/flask/templates/imageset_move.html
+++ b/img_catalog_tui/flask/templates/imageset_move.html
@@ -1,0 +1,153 @@
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block page_title %}{{ title }}{% endblock %}
+
+{% block content %}
+{% if error %}
+    <div class="error-message">
+        {{ error }}
+    </div>
+{% else %}
+    <div class="section">
+        <h2 class="section-title">Move Imageset</h2>
+        <div class="folder-path" style="font-family: var(--font-mono); background: var(--muted); padding: var(--space-sm); border-radius: var(--radius-sm); margin-bottom: var(--space-md); word-break: break-all;">
+            {{ foldername }} / {{ imageset_name }}
+        </div>
+        
+        {% if imageset_data %}
+            <div class="card" style="max-width: 800px;">
+                <div class="card-header">
+                    <h3 style="margin: 0; color: var(--accent); font-size: 1.1rem;">📦 Move to Folder</h3>
+                </div>
+                <div class="card-content">
+                    <p style="margin-bottom: var(--space-lg); color: var(--text); opacity: 0.9;">
+                        Select the destination folder for this imageset. The imageset will be moved from 
+                        <strong>{{ foldername }}</strong> to the selected folder.
+                    </p>
+                    
+                    <form id="moveForm" style="display: grid; gap: var(--space-md);">
+                        <!-- Target Folder Selection -->
+                        <div class="form-group">
+                            <label for="target_folder" style="display: block; font-weight: 600; margin-bottom: var(--space-xs); color: var(--text);">
+                                Target Folder
+                            </label>
+                            <select id="target_folder" name="target_folder" class="form-control" required style="width: 100%; padding: var(--space-sm); border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg); color: var(--text);">
+                                <option value="">Select destination folder...</option>
+                                {% for folder_key, folder_path in available_folders.items() %}
+                                    {% if folder_key != foldername %}
+                                        <option value="{{ folder_key }}">{{ folder_key }}</option>
+                                    {% endif %}
+                                {% endfor %}
+                            </select>
+                            <div style="font-size: 0.75rem; color: var(--text); opacity: 0.7; margin-top: var(--space-xs);">
+                                Choose a different folder to move this imageset to.
+                            </div>
+                        </div>
+                        
+                        <!-- Warning Message -->
+                        <div style="background: var(--muted); padding: var(--space-md); border-radius: var(--radius-sm); border-left: 4px solid var(--accent);">
+                            <strong>⚠️ Important:</strong> This action will move the entire imageset folder to the selected location.
+                        </div>
+                    </form>
+                </div>
+            </div>
+            
+            <!-- Form Actions -->
+            <div class="section" style="margin-top: var(--space-lg); padding-top: var(--space-md); border-top: 1px solid var(--border); max-width: 800px;">
+                <div style="display: flex; gap: var(--space-md); flex-wrap: wrap;">
+                    <button type="button" id="moveBtn" class="btn btn-primary">
+                        📦 Move Imageset
+                    </button>
+                    <a href="/imageset/{{ foldername }}/{{ imageset_name }}" class="btn btn-secondary">
+                        ❌ Cancel
+                    </a>
+                    <a href="/folder/{{ foldername }}" class="btn btn-secondary">
+                        ← Back to Folder
+                    </a>
+                </div>
+            </div>
+            
+            <!-- Status Message Area -->
+            <div id="statusMessage" style="margin-top: var(--space-md); max-width: 800px;"></div>
+        {% endif %}
+    </div>
+{% endif %}
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const moveBtn = document.getElementById('moveBtn');
+    const targetFolder = document.getElementById('target_folder');
+    const statusMessage = document.getElementById('statusMessage');
+    
+    moveBtn.addEventListener('click', function() {
+        const targetFolderValue = targetFolder.value;
+        
+        // Validate selection
+        if (!targetFolderValue) {
+            showMessage('Please select a destination folder.', 'error');
+            return;
+        }
+        
+        // Confirm action
+        if (!confirm(`Are you sure you want to move this imageset to "${targetFolderValue}"?`)) {
+            return;
+        }
+        
+        // Disable button and show loading state
+        moveBtn.disabled = true;
+        moveBtn.textContent = '⏳ Moving...';
+        
+        // Make API call
+        fetch('/api/imageset/{{ foldername }}/{{ imageset_name }}/move', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                target_foldername: targetFolderValue
+            })
+        })
+        .then(response => {
+            if (!response.ok) {
+                return response.json().then(data => {
+                    throw new Error(data.error || 'Failed to move imageset');
+                });
+            }
+            return response.json();
+        })
+        .then(data => {
+            showMessage('✅ Imageset moved successfully! Redirecting...', 'success');
+            
+            // Redirect to the imageset in the new folder after a short delay
+            setTimeout(() => {
+                window.location.href = `/imageset/${targetFolderValue}/{{ imageset_name }}`;
+            }, 1500);
+        })
+        .catch(error => {
+            showMessage('❌ Error: ' + error.message, 'error');
+            moveBtn.disabled = false;
+            moveBtn.textContent = '📦 Move Imageset';
+        });
+    });
+    
+    function showMessage(message, type) {
+        const messageClass = type === 'error' ? 'error-message' : 'success-message';
+        statusMessage.innerHTML = `<div class="${messageClass}" style="padding: var(--space-md); border-radius: var(--radius-sm);">${message}</div>`;
+    }
+    
+    // Add keyboard shortcut
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') {
+            window.location.href = '/imageset/{{ foldername }}/{{ imageset_name }}';
+        }
+    });
+});
+</script>
+{% endblock %}
+
+

--- a/img_catalog_tui/flask/urls.py
+++ b/img_catalog_tui/flask/urls.py
@@ -16,6 +16,7 @@ def register_routes(app):
     # Imageset
     app.add_url_rule('/imageset/<string:foldername>/<string:imageset_name>', endpoint='imageset', view_func=views_html.imageset)
     app.add_url_rule('/imageset/<string:foldername>/<string:imageset_name>/edit', endpoint='imageset_edit', view_func=views_html.imageset_edit)
+    app.add_url_rule('/imageset/<string:foldername>/<string:imageset_name>/move', endpoint='imageset_move_form', view_func=views_html.imageset_move_form)
     app.add_url_rule('/imageset/<string:foldername>/<string:imageset_name>/interview', endpoint='interview', view_func=views_html.interview)
     # app.add_url_rule('/imageset/<string:foldername>/<string:imageset_name/toml>', endpoint='imageset_toml', view_func=views_html.imageset_toml)
     
@@ -48,10 +49,12 @@ def register_routes(app):
     
     app.add_url_rule('/api/folder/<string:foldername>', endpoint='api_folder', view_func=views_api.folder)
     app.add_url_rule('/api/folder/<string:foldername>/batch_update', endpoint='api_batch_update', view_func=views_api.batch_update, methods=['POST'])
+    app.add_url_rule('/api/folder/<string:foldername>/move_imagesets', endpoint='api_move_imagesets', view_func=views_api.move_imagesets, methods=['POST'])
     
     
     app.add_url_rule('/api/imageset/<string:foldername>/<string:imageset>', endpoint='api_imageset', view_func=views_api.imageset, methods=['GET'])
     app.add_url_rule('/api/imageset/<string:foldername>/<string:imageset>/update', endpoint='api_imageset_update', view_func=views_api.imageset_update, methods=['POST'])
+    app.add_url_rule('/api/imageset/<string:foldername>/<string:imageset>/move', endpoint='api_imageset_move', view_func=views_api.imageset_move, methods=['POST'])
     
     app.add_url_rule('/api/folder/<string:foldername>/review/new', endpoint='api_review_new', view_func=views_api.review_new)
 


### PR DESCRIPTION
Add ability to move ImageSets between folders via web interface.

- Core: move_to_folder() method in ImageSet class
- API: Single and bulk move endpoints with status filtering
- UI: Move buttons on ImageSet page, folder cards, and status cards
- Template: Interactive folder selection dialog with feedback

Fixes #10 
Closes #10 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add core method and API/UI to move single or multiple ImageSets (including by status) between folders.
> 
> - **Core**:
>   - Implement `Imageset.move_to_folder(new_folder_path)` with validation, filesystem move, state updates, and TOML reinit in `img_catalog_tui/core/imageset.py`.
> - **API**:
>   - Add single-move endpoint `POST /api/imageset/<foldername>/<imageset>/move`.
>   - Add bulk move endpoint `POST /api/folder/<foldername>/move_imagesets` supporting list or `filter_status`, with 200/207/500 responses.
> - **HTML/UI**:
>   - New move form and template `imageset_move.html`; add view `imageset_move_form`.
>   - Enhance `folder.html`: per-imageset "Move" link, status-card "Move" buttons, and "Move All Imagesets" dialog with client-side feedback.
>   - Enhance `imageset.html`: add "Move ImageSet" action button.
> - **Routing**:
>   - Register new routes in `img_catalog_tui/flask/urls.py` for HTML and API move operations.
> - **Docs**:
>   - Add `docs/issue10_move_to_folder.md` outlining implementation steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68ea25c41bbd342870f88ab4a8c503008fd83db2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->